### PR TITLE
Add option to disable autoflood when going afk

### DIFF
--- a/localization.en.lua
+++ b/localization.en.lua
@@ -16,6 +16,11 @@ AUTOFLOOD_INACTIVE = "AutoFlood is disabled."
 AUTOFLOOD_ERR_CHAN = "The channel /CHANNEL doesn't exist."
 AUTOFLOOD_ERR_RATE = "You can't send messages less than every RATE seconds."
 
+AUTOFLOOD_TOGGLE_ON_AFK = "Toggle on AFK is: STATE"
+
+AUTOFLOOD_STATE_DISABLED = "disabled"
+AUTOFLOOD_STATE_ENABLED = "enabled"
+
 AUTOFLOOD_HELP = {
 	"===================== Auto Flood =====================",
 	"/flood [on|off] : Start / stops sending the message.",
@@ -24,4 +29,5 @@ AUTOFLOOD_HELP = {
 	"/floodrate <duration> : Sets the period (in seconds).",
 	"/floodinfo : Displays parameters.",
 	"/floodhelp : Displays this help message.",
+    "/floodafk [on|off] : Start/stop disable sending the message on AFK",
 }

--- a/localization.fr.lua
+++ b/localization.fr.lua
@@ -16,6 +16,11 @@ if (GetLocale() == "frFR") then
 	AUTOFLOOD_ERR_CHAN = "Le canal /CHANNEL est invalide."
 	AUTOFLOOD_ERR_RATE = "Vous ne pouvez pas envoyer de messages à moins de RATE secondes d'intervalle."
 
+    AUTOFLOOD_TOGGLE_ON_AFK = "Toggle on AFK is: STATE"
+
+    AUTOFLOOD_STATE_DISABLED = "disabled"
+    AUTOFLOOD_STATE_ENABLED = "enabled"
+
 	AUTOFLOOD_HELP = {
 		"===================== Auto Flood =====================",
 		"/flood [on|off] : Démarre / arrête l'envoi du message.",


### PR DESCRIPTION
The option can be enabled with /floodafk [on|off].
I don't speak french so I copied the English string I created
to the french translation.